### PR TITLE
json_fix() support for javascript classes 

### DIFF
--- a/JSON.php
+++ b/JSON.php
@@ -828,7 +828,8 @@ class Services_JSON
                 } else {
                     
                         //Ensures string value is doubleQuoted whatever is provided so we do 
-                        // have null value for js/object class names or instances.
+                        // ie fix null value for js/object class names or instances.
+                        // and handles regexp /foo/
                         
                         if (preg_match('/^("|\').*(\1)$/s', $str, $m) && $m[1] == $m[2]) {
                             $delim=$m[1];
@@ -841,7 +842,13 @@ class Services_JSON
                         if($delim) {
                             $str=$delim.$str.$delim;
                         }else {
-                            $str='"${'.$str.'}"'; //This is the best I can do, resolving back to class must be done separatly
+                            if(preg_match('#^(\/).*(\1)$#s',$str,$m) && $m[1] == $m[2]) { 
+                                //Regexp my Lord, prevent escaping slash delimiters
+                                $str='"${#'.substr($str,1,-1).'#}"'; 
+                            } else {
+                                //This is the best I can do for values laquing of doublequote, ie js classes instances, resolving back to class must be done separatly
+                                $str='"${'.$str.'}"';
+                            }
                         }
                         //echo("<br><b>Processing $str</b>");
        

--- a/JSON.php
+++ b/JSON.php
@@ -677,103 +677,6 @@ class Services_JSON
                         ? (integer)$str
                         : (float)$str;
 
-                } elseif (preg_match('/^("|\').*(\1)$/s', $str, $m) && $m[1] == $m[2]) {
-                    // STRINGS RETURNED IN UTF-8 FORMAT
-                    $delim = $this->substr8($str, 0, 1);
-                    $chrs = $this->substr8($str, 1, -1);
-                    $utf8 = '';
-                    $strlen_chrs = $this->strlen8($chrs);
-
-                    for ($c = 0; $c < $strlen_chrs; ++$c) {
-
-                        $substr_chrs_c_2 = $this->substr8($chrs, $c, 2);
-                        $ord_chrs_c = ord($chrs{$c});
-
-                        switch (true) {
-                            case $substr_chrs_c_2 == '\b':
-                                $utf8 .= chr(0x08);
-                                ++$c;
-                                break;
-                            case $substr_chrs_c_2 == '\t':
-                                $utf8 .= chr(0x09);
-                                ++$c;
-                                break;
-                            case $substr_chrs_c_2 == '\n':
-                                $utf8 .= chr(0x0A);
-                                ++$c;
-                                break;
-                            case $substr_chrs_c_2 == '\f':
-                                $utf8 .= chr(0x0C);
-                                ++$c;
-                                break;
-                            case $substr_chrs_c_2 == '\r':
-                                $utf8 .= chr(0x0D);
-                                ++$c;
-                                break;
-
-                            case $substr_chrs_c_2 == '\\"':
-                            case $substr_chrs_c_2 == '\\\'':
-                            case $substr_chrs_c_2 == '\\\\':
-                            case $substr_chrs_c_2 == '\\/':
-                                if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
-                                   ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
-                                    $utf8 .= $chrs{++$c};
-                                }
-                                break;
-
-                            case preg_match('/\\\u[0-9A-F]{4}/i', $this->substr8($chrs, $c, 6)):
-                                // single, escaped unicode character
-                                $utf16 = chr(hexdec($this->substr8($chrs, ($c + 2), 2)))
-                                       . chr(hexdec($this->substr8($chrs, ($c + 4), 2)));
-                                $utf8 .= $this->utf162utf8($utf16);
-                                $c += 5;
-                                break;
-
-                            case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                                $utf8 .= $chrs{$c};
-                                break;
-
-                            case ($ord_chrs_c & 0xE0) == 0xC0:
-                                // characters U-00000080 - U-000007FF, mask 110XXXXX
-                                //see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $utf8 .= $this->substr8($chrs, $c, 2);
-                                ++$c;
-                                break;
-
-                            case ($ord_chrs_c & 0xF0) == 0xE0:
-                                // characters U-00000800 - U-0000FFFF, mask 1110XXXX
-                                // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $utf8 .= $this->substr8($chrs, $c, 3);
-                                $c += 2;
-                                break;
-
-                            case ($ord_chrs_c & 0xF8) == 0xF0:
-                                // characters U-00010000 - U-001FFFFF, mask 11110XXX
-                                // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $utf8 .= $this->substr8($chrs, $c, 4);
-                                $c += 3;
-                                break;
-
-                            case ($ord_chrs_c & 0xFC) == 0xF8:
-                                // characters U-00200000 - U-03FFFFFF, mask 111110XX
-                                // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $utf8 .= $this->substr8($chrs, $c, 5);
-                                $c += 4;
-                                break;
-
-                            case ($ord_chrs_c & 0xFE) == 0xFC:
-                                // characters U-04000000 - U-7FFFFFFF, mask 1111110X
-                                // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $utf8 .= $this->substr8($chrs, $c, 6);
-                                $c += 5;
-                                break;
-
-                        }
-
-                    }
-
-                    return $utf8;
-
                 } elseif (preg_match('/^\[.*\]$/s', $str) || preg_match('/^\{.*\}$/s', $str)) {
                     // array, or object notation
 
@@ -922,6 +825,122 @@ class Services_JSON
 
                     }
 
+                } else {
+                    
+                        //Ensures string value is doubleQuoted whatever is provided so we do 
+                        // have null value for js/object class names or instances.
+                        
+                        if (preg_match('/^("|\').*(\1)$/s', $str, $m) && $m[1] == $m[2]) {
+                            $delim=$m[1];
+                        }else {
+                            $delim='';
+                        }
+                        
+                        $str=trim($str,'"|\'');
+                        
+                        if($delim) {
+                            $str=$delim.$str.$delim;
+                        }else {
+                            $str='"${'.$str.'}"'; //This is the best I can do, resolving back to class must be done separatly
+                        }
+                        //echo("<br><b>Processing $str</b>");
+       
+                        // STRINGS RETURNED IN UTF-8 FORMAT
+                        $delim = $this->substr8($str, 0, 1);
+                        $chrs = $this->substr8($str, 1, -1);
+                        $utf8 = '';
+                        $strlen_chrs = $this->strlen8($chrs);
+
+                        for ($c = 0; $c < $strlen_chrs; ++$c) {
+
+                            $substr_chrs_c_2 = $this->substr8($chrs, $c, 2);
+                            $ord_chrs_c = ord($chrs{$c});
+
+                            switch (true) {
+                                case $substr_chrs_c_2 == '\b':
+                                    $utf8 .= chr(0x08);
+                                    ++$c;
+                                    break;
+                                case $substr_chrs_c_2 == '\t':
+                                    $utf8 .= chr(0x09);
+                                    ++$c;
+                                    break;
+                                case $substr_chrs_c_2 == '\n':
+                                    $utf8 .= chr(0x0A);
+                                    ++$c;
+                                    break;
+                                case $substr_chrs_c_2 == '\f':
+                                    $utf8 .= chr(0x0C);
+                                    ++$c;
+                                    break;
+                                case $substr_chrs_c_2 == '\r':
+                                    $utf8 .= chr(0x0D);
+                                    ++$c;
+                                    break;
+
+                                case $substr_chrs_c_2 == '\\"':
+                                case $substr_chrs_c_2 == '\\\'':
+                                case $substr_chrs_c_2 == '\\\\':
+                                case $substr_chrs_c_2 == '\\/':
+                                    if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
+                                    ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
+                                        $utf8 .= $chrs{++$c};
+                                    }
+                                    break;
+
+                                case preg_match('/\\\u[0-9A-F]{4}/i', $this->substr8($chrs, $c, 6)):
+                                    // single, escaped unicode character
+                                    $utf16 = chr(hexdec($this->substr8($chrs, ($c + 2), 2)))
+                                        . chr(hexdec($this->substr8($chrs, ($c + 4), 2)));
+                                    $utf8 .= $this->utf162utf8($utf16);
+                                    $c += 5;
+                                    break;
+
+                                case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
+                                    $utf8 .= $chrs{$c};
+                                    break;
+
+                                case ($ord_chrs_c & 0xE0) == 0xC0:
+                                    // characters U-00000080 - U-000007FF, mask 110XXXXX
+                                    //see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
+                                    $utf8 .= $this->substr8($chrs, $c, 2);
+                                    ++$c;
+                                    break;
+
+                                case ($ord_chrs_c & 0xF0) == 0xE0:
+                                    // characters U-00000800 - U-0000FFFF, mask 1110XXXX
+                                    // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
+                                    $utf8 .= $this->substr8($chrs, $c, 3);
+                                    $c += 2;
+                                    break;
+
+                                case ($ord_chrs_c & 0xF8) == 0xF0:
+                                    // characters U-00010000 - U-001FFFFF, mask 11110XXX
+                                    // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
+                                    $utf8 .= $this->substr8($chrs, $c, 4);
+                                    $c += 3;
+                                    break;
+
+                                case ($ord_chrs_c & 0xFC) == 0xF8:
+                                    // characters U-00200000 - U-03FFFFFF, mask 111110XX
+                                    // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
+                                    $utf8 .= $this->substr8($chrs, $c, 5);
+                                    $c += 4;
+                                    break;
+
+                                case ($ord_chrs_c & 0xFE) == 0xFC:
+                                    // characters U-04000000 - U-7FFFFFFF, mask 1111110X
+                                    // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
+                                    $utf8 .= $this->substr8($chrs, $c, 6);
+                                    $c += 5;
+                                    break;
+
+                            }
+
+                        }
+
+                        return $utf8;
+                    
                 }
         }
     }

--- a/JSON.php
+++ b/JSON.php
@@ -846,7 +846,7 @@ class Services_JSON
                                 //Regexp my Lord, prevent escaping slash delimiters
                                 $str='"${#'.substr($str,1,-1).'#}"'; 
                             } else {
-                                //This is the best I can do for values laquing of doublequote, ie js classes instances, resolving back to class must be done separatly
+                                //This is the best I can do for values lacking of doublequote, ie js classes instances, resolving back to class must be done separatly
                                 $str='"${'.$str.'}"';
                             }
                         }

--- a/Test-JSON.php
+++ b/Test-JSON.php
@@ -475,6 +475,38 @@
             $this->assertEquals($this->obj_j_, $this->json_->encode($this->obj), "object case: {$this->obj_d}");
         }
     }
+    
+     class Services_JSON_FixJson_TestCase extends PHPUnit_TestCase {
+
+        function Services_JSON_FixJson_TestCase($name) {
+            $this->PHPUnit_TestCase($name);
+        }
+
+        function setUp() {
+            $this->json = new Services_JSON(SERVICES_JSON_IN_ARR|SERVICES_JSON_USE_TO_JSON| SERVICES_JSON_LOOSE_TYPE);
+
+            $this->arn_ja = "{sos:presents,james:'bond',agent:[0,0,7],secret:\"{mission:'impossible',permit:\"tokill\"}\",go:true }";
+            $this->arn_ja_fixed ="{\"sos\":\"presents\",\"james\":'bond',\"agent\":[0,0,7],\"secret\":\"{mission:'impossible',permit:\"tokill\"}\",\"go\":true}";
+            $this->arn_d = 'Json Fix test case with undoublequoted keys and values, challenging decoding specially for classes and json values';
+
+        }
+
+        function test_from_JSON()
+        {
+            //back to Class, PHP compatible (loose mode for JS) else JS compatible (broken for PHP)
+            function backToClass($json, $class="PHP") {
+                $repl=($class =="PHP") ? '"$1"' : '$1';
+                return preg_replace('/"\$\{(.*)\}"/ismU', $repl, $json);
+            }
+            
+            function json_fix($json,$to="PHP") {
+                return backToClass(json_encode($this->json->decode($json),true),$to);
+            }
+            // Test if decode and backToClass get it to the original 
+            $this->assertEquals(json_decode($this->arn_ja_fixed,true), json_decode(json_fix($this->arn_ja),true), "Json in javascript world fixed for json in php world and then back without loosing anybody");
+        }
+    }
+
 
     $suite  = new PHPUnit_TestSuite('Services_JSON_EncDec_TestCase');
     $result = PHPUnit::run($suite);
@@ -508,4 +540,7 @@
     $result = PHPUnit::run($suite);
     echo $result->toString();
 
+    $suite  = new PHPUnit_TestSuite('Services_JSON_FixJson_TestCase');
+    $result = PHPUnit::run($suite);
+    echo $result->toString();
 ?>

--- a/Test-JSONFIX.php
+++ b/Test-JSONFIX.php
@@ -1,0 +1,135 @@
+<?php
+
+// $Id$
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Unit tests for Services_JSONFIX.
+ * @see JSON.php
+ *
+ * @category
+ * @package     Services_JSON
+ * @author      Olivier Lutzwiller
+ * @copyright   2020 sos-productions.com
+ * @version     CVS: $Id$
+ * @license     http://www.opensource.org/licenses/bsd-license.php
+ * @link        https://stackoverflow.com/questions/13236819/how-to-fix-badly-formatted-json-in-php/63492087#63492087
+ */
+ 
+include("JSON.php"); //Patched version 
+	
+
+$arn_ja = "{sos:presents,james:'bond',agent:[0,0,7],secret:\"{mission:'impossible',permit:\"tokill\"}\",go:true }";
+$arn_ja_valid ="{\"sos\":\"presents\",\"james\":\"bond\",\"agent\":[0,0,7],\"secret\":\"{mission:'impossible',permit:\\\"tokill\\\"}\",\"go\":true}";
+$arn_d = 'Json Fix test case with undoublequoted keys and values, challenging decoding specially for classes and json values';
+
+
+//back to Class, PHP compatible (loose mode for JS) else JS compatible (broken for PHP)
+function backToClass($json, $class="PHP") {
+    $repl=($class =="PHP") ? '"$1"' : '$1';
+    return preg_replace('/"\$\{(.*)\}"/ismU', $repl, $json);
+}
+
+function json_fix($json,$to="PHP",$skipBackToClass=false) {
+    $sjson = new Services_JSON(SERVICES_JSON_IN_ARR|SERVICES_JSON_USE_TO_JSON| SERVICES_JSON_LOOSE_TYPE);
+    $json=json_encode($sjson->decode($json),true);
+    if(!$skipBackToClass) $json=backToClass($json,$to);
+    return $json;
+}
+
+
+echo "<h1>json_fix PHPUnit test check by sos-productions.com using patched Services_JSON</h1><br><em>Note this replaces PHPUnit Gas factory I did not manage to install with php7 from pear</em><hr><ol><li>Let's take for the example json source (arn_ja) coming from Javascript world:
+<pre>";
+    
+    echo htmlentities($arn_ja);
+    
+    echo "</pre></li><li>In PHP world, json_decode(arn_ja) gives:<div><pre>";
+            
+    $arn_fail=json_decode($arn_ja,true);
+    
+    if(json_last_error() != JSON_ERROR_NONE) {
+    
+        echo(json_last_error_msg());
+    }
+    
+    echo "</li>";
+
+echo "<li>fixed json arn_ja for php's world with json_fix(arn_ja) gives arn_ja_fixed:";
+
+
+$arn_ja_fixed=json_fix($arn_ja);
+
+
+$arn_fixed=json_decode($arn_ja_fixed,true);
+ if(json_last_error() == JSON_ERROR_NONE) {
+
+    //$json=json_encode($json_array);//,JSON_PRETTY_PRINT);
+    
+    echo "<pre>";
+    
+    echo "$arn_ja_fixed";
+    
+    echo "</pre></li><li>json_decode(arn_ja_fixed) gives arn_fixed:<div><pre>";
+            
+    print_r($arn_fixed);
+    
+    echo "</pre></div></li>";
+    
+    
+  
+    $arn_valid=json_decode($arn_ja_valid,true);
+    
+    if(json_last_error() == JSON_ERROR_NONE) {
+    
+        echo "<li><p>We expected equivalent with dump(arn_ja_valid): <div><pre>";
+                
+        var_dump($arn_valid);
+        
+        echo "</pre></div></li>";
+    
+    
+        
+    }else {
+        echo(json_last_error_msg()); 
+    }
+    
+     echo "<li>So result is: ";
+     
+    if($arn_fixed == $arn_valid) {
+        echo "Success, arn_ja has been fixed for PHP world with json_fix(arn_ja). This has been made in two steps.<br>a)decode without back to class (arn_ja_partial_fix) with json_fix(arn_ja,'PHP',true)";
+        $arn_ja_partial_fix=json_fix($arn_ja,"PHP",true);
+        echo "<pre>";
+        echo htmlentities($arn_ja_partial_fix);
+        echo "</pre>";
+        echo "<br>b) and then back to class to PHP with backToClass(arn_ja_partial_fix,'PHP') ";
+         echo "<pre>";
+        echo backToClass($arn_ja_partial_fix,"PHP");
+        echo "</pre>";
+        echo "<br><u>Note</u> We could have done a processing on a) and then return back to class in JS world with backToClass(arn_ja_partial_fix,'JS') giving:";
+         echo "<pre>";
+        echo backToClass($arn_ja_partial_fix,"JS");
+         echo "</pre> which is quite equivalent to arn_ja in JS world with the keys were doublequoted in the process.<br> However json_decode(backToClass(arn_ja_partial_fix,'JS') produces ";
+         $try=json_decode(backToClass($arn_ja_partial_fix,"JS"),true);
+          if(json_last_error() != JSON_ERROR_NONE) {
+            echo(json_last_error_msg());
+          }
+          echo " because in PHP world values exept array and object, numerical or boolean need to be doublequoted, define('presents',1) may have make json_decode happy..but not we still have ";
+         define('presents',1);
+           $retry=json_decode(backToClass($arn_ja_partial_fix,"JS"),true);
+          if(json_last_error() != JSON_ERROR_NONE) {
+            echo(json_last_error_msg());
+          }
+          
+        }else {
+        echo "FAILURE";
+    }
+    
+    
+} else {
+   echo(json_last_error_msg());
+}
+
+echo "</li></ol>";
+
+
+?>

--- a/Test-JSONFIX.php
+++ b/Test-JSONFIX.php
@@ -19,6 +19,9 @@
 include("JSON.php"); //Patched version 
 	
 
+define("SHOW_TRANSIENT_JSON_FIXED",0);
+
+
 $arn_ja = "{sos:presents,james:'bond',agent:[0,0,7],secret:\"{mission:'impossible',permit:\"tokill\"}\",go:true, regex: /https:\/\/player.blubrry.com\/id\/([^\/]+)/}";
 $arn_ja_valid ="{\"sos\":\"presents\",\"james\":\"bond\",\"agent\":[0,0,7],\"secret\":\"{mission:'impossible',permit:\\\"tokill\\\"}\",\"go\":true,\"regex\": \"/https:\/\/player.blubrry.com\/id\/([^\/]+)/\"}";
 
@@ -39,7 +42,7 @@ function backToClass($json, $class="PHP") {
 function json_fix($json,$to="PHP",$skipBackToClass=false) {
     $sjson = new Services_JSON(SERVICES_JSON_IN_ARR|SERVICES_JSON_USE_TO_JSON| SERVICES_JSON_LOOSE_TYPE);
     
-     echo(htmlentities(var_export($sjson->decode($json),true)));
+    if(SHOW_TRANSIENT_JSONFIXED) echo(htmlentities(var_export($sjson->decode($json),true)));
     
     $json=json_encode($sjson->decode($json),true);
     if(!$skipBackToClass) $json=backToClass($json,$to);

--- a/Test-JSONFIX.php
+++ b/Test-JSONFIX.php
@@ -19,19 +19,28 @@
 include("JSON.php"); //Patched version 
 	
 
-$arn_ja = "{sos:presents,james:'bond',agent:[0,0,7],secret:\"{mission:'impossible',permit:\"tokill\"}\",go:true }";
-$arn_ja_valid ="{\"sos\":\"presents\",\"james\":\"bond\",\"agent\":[0,0,7],\"secret\":\"{mission:'impossible',permit:\\\"tokill\\\"}\",\"go\":true}";
+$arn_ja = "{sos:presents,james:'bond',agent:[0,0,7],secret:\"{mission:'impossible',permit:\"tokill\"}\",go:true, regex: /https:\/\/player.blubrry.com\/id\/([^\/]+)/}";
+$arn_ja_valid ="{\"sos\":\"presents\",\"james\":\"bond\",\"agent\":[0,0,7],\"secret\":\"{mission:'impossible',permit:\\\"tokill\\\"}\",\"go\":true,\"regex\": \"/https:\/\/player.blubrry.com\/id\/([^\/]+)/\"}";
+
+
 $arn_d = 'Json Fix test case with undoublequoted keys and values, challenging decoding specially for classes and json values';
 
 
 //back to Class, PHP compatible (loose mode for JS) else JS compatible (broken for PHP)
 function backToClass($json, $class="PHP") {
+    //unprotect regexp delimiters values
+    $repl=($class =="PHP") ? '"/$1/"' : '/$1/';
+    $tjson=preg_replace('/"\${#(.*)#}"/ismU', $repl, $json);
+    //unprotext undoublequoted values
     $repl=($class =="PHP") ? '"$1"' : '$1';
-    return preg_replace('/"\$\{(.*)\}"/ismU', $repl, $json);
+    return preg_replace('/"\${(.*)}"/ismU', $repl, $tjson);
 }
 
 function json_fix($json,$to="PHP",$skipBackToClass=false) {
     $sjson = new Services_JSON(SERVICES_JSON_IN_ARR|SERVICES_JSON_USE_TO_JSON| SERVICES_JSON_LOOSE_TYPE);
+    
+     echo(htmlentities(var_export($sjson->decode($json),true)));
+    
     $json=json_encode($sjson->decode($json),true);
     if(!$skipBackToClass) $json=backToClass($json,$to);
     return $json;
@@ -90,7 +99,7 @@ $arn_fixed=json_decode($arn_ja_fixed,true);
     
         
     }else {
-        echo(json_last_error_msg()); 
+        echo('json_decode($arn_ja_valid,true) with $arn_ja_valid='.$arn_ja_valid.' retruns'.json_last_error_msg()); 
     }
     
      echo "<li>So result is: ";

--- a/package2.xml
+++ b/package2.xml
@@ -5,7 +5,7 @@ http://pear.php.net/dtd/package-2.0
 http://pear.php.net/dtd/package-2.0.xsd">
  <name>Services_JSON</name>
  <channel>pear.php.net</channel>
- <summary>PHP implementaion of json_encode/decode</summary>
+ <summary>PHP implementation of json_encode/decode</summary>
  <description> 
 JSON (JavaScript Object Notation, http://json.org) is a lightweight data-interchange format. 
     It is easy for humans to read and write. It is easy for machines to parse and generate. 
@@ -36,16 +36,20 @@ JSON (JavaScript Object Notation, http://json.org) is a lightweight data-interch
  </lead>
  
  
- <date>2011-01-14</date>
+ 
+ <date>2020-08-20</date>
  
  <version>
-  <release>1.0.3</release>
+  <release>1.0.4</release>
   <api>1.0.0</api>
  </version>
  <stability>
   <release>stable</release>
   <api>stable</api>
  </stability>
+ 
+ 
+ 
 
  <license>BSD</license>
  <notes><![CDATA[
@@ -97,6 +101,17 @@ echo $sj->encode(new A());
 
         <release>
  
+                <date>2011-01-14</date>
+ 
+                <version>
+                 <release>1.0.3</release>
+                 <api>1.0.0</api>
+                </version>
+                <stability>
+                 <release>stable</release>
+                 <api>stable</api>
+                </stability>
+            
 
                  <date>2009-01-02</date>
                  


### PR DESCRIPTION
Service_JSON::decode is giving null for other value types than standard types string,array,object,integer,boolean

 In javascript (JS) these other types values are unquoted, representing a pointer to an instance of a class.
a)Thus { james: bond }  will be decoded as {james: null } on PHP side having no idea of what "bond" is. 
we can hook this to {"james":"${bond}"} 
b)For regexps  such as { 'played by': /(Sean Connery|Roger Moore|Timolty Dalton)/ }
we can hook this to a transient string form  {"'played by": "${#(Sean Connery|Roger Moore|Timolty Dalton)#}" }

and decide whether world JS or PHP we want to decode it using the second parameter of backToClass() thus the JSON bridge between the two worlds  JS and PHP is done. 

I read how json_decode() can annoy the world with bad formated JSON from JS world that may have keys and values not doublequotted, contains commas, are not slashed...it is time to end this nightmare of fixing json so json_decode is happy
in PHP! Disscussions started here and here on stackoverflow with a lot of tries with complex regexp stuff like here:
https://stackoverflow.com/questions/13236819/how-to-fix-badly-formatted-json-in-php/63492087
that will fail if values contains stringified json and Service_JSON passed the test if class is not lost...
